### PR TITLE
(DEL-1774) Update Slack Addon to New NATS Auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ config.*
 nats.nkey
 audit.log
 .env
+user.local.creds

--- a/README.md
+++ b/README.md
@@ -16,12 +16,31 @@ As a side-note, users in Slack Enterprise Grid exist at the organization level b
 
 ### Pre-requisites for running locally
 
-You can run `gov-slack-addon` against your local Governor instance (if you don't already have one, follow the directions [here](https://github.com/equinixmetal/governor/blob/main/README.md#running-governor-locally).
+Follow the directions [here](https://github.com/equinixmetal/governor/blob/main/README.md#running-governor-locally) for starting the governor-api devcontainer.
 
-The first time you'll need to create a local hydra client for `gov-slack-addon-governor` (you do this where hydra is running, so most likely the governor-api):
+The **first time** you'll need to create a local hydra client for `gov-slack-addon-governor` and copy the nats creds file. After that you can just export the env variables.
 
+First create a local audit log for testing in the `gov-slack-addon` directory:
+
+```sh
+touch audit.log
 ```
+
+#### NATS Creds
+
+Run in the governor-api devcontainer:
+
+```sh
+cat /tmp/user.creds
+```
+
+Then create and copy into `gov-slack-addon/user.local.creds`
+
+#### Hydra
+
+```sh
 export GSA_GOVERNOR_CLIENT_ID="gov-slack-addon-governor"
+# Copy for env variable later
 export GSA_GOVERNOR_CLIENT_SECRET="$(openssl rand -hex 16)"
 echo "${GSA_GOVERNOR_CLIENT_SECRET}"
 
@@ -36,9 +55,11 @@ hydra clients create \
     --scope read:governor:users,read:governor:groups,read:governor:applications
 ```
 
+#### Env
+
 Export the required env variables to point to our local Governor and Hydra:
 
-```
+```sh
 export GSA_GOVERNOR_URL="http://127.0.0.1:3001"
 export GSA_GOVERNOR_AUDIENCE="http://api:3001/"
 export GSA_GOVERNOR_TOKEN_URL="http://127.0.0.1:4444/oauth2/token"
@@ -48,21 +69,27 @@ export GSA_NATS_TOKEN="notused"
 
 Also ensure you have the following secrets exported:
 
-```
+```sh
+# Retrieve from pw vault, look for governor tag
 export GSA_SLACK_TOKEN="REPLACE"
 export GSA_GOVERNOR_CLIENT_SECRET="REPLACE"
 ```
 
-Create a local audit log for testing in the `gov-slack-addon` directory:
+#### Troubleshooting
 
-```
-touch audit.log
-```
+**"error": "Unable to insert or update resource because a resource with that value exists already"**
+
+Run `hydra clients delete gov-slack-addon-governor` in the governor-api devcontainer. Then rerun the steps for hydra.
+
+**"error": "error",**
+**"error_description": "The error is unrecognizable"**
+
+Same as above.
 
 ### Testing addon locally
 
 Start the addon (adjust the flags as needed):
 
-```
-go run . serve --audit-log-path=audit.log --pretty --development --debug --dry-run
+```sh
+go run . serve --audit-log-path=audit.log --pretty --debug --dry-run
 ```

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -5,8 +5,8 @@ import "errors"
 var (
 	// ErrNATSURLRequired is returned when a NATS url is missing
 	ErrNATSURLRequired = errors.New("nats url is required and cannot be empty")
-	// ErrNATSAuthRequired is returned when a NATS auth method is missing
-	ErrNATSAuthRequired = errors.New("nats token or nkey auth is required and cannot be empty")
+	// ErrMissingNATSCreds is returned when nats creds are not provided
+	ErrMissingNATSCreds = errors.New("nats creds are required")
 	// ErrGovernorURLRequired is returned when a governor URL is missing
 	ErrGovernorURLRequired = errors.New("governor url is required and cannot be empty")
 	// ErrGovernorClientIDRequired is returned when a governor client id is missing

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,9 +41,6 @@ func init() {
 
 	rootCmd.PersistentFlags().Bool("pretty", false, "enable pretty (human readable) logging output")
 	viperBindFlag("logging.pretty", rootCmd.PersistentFlags().Lookup("pretty"))
-
-	rootCmd.PersistentFlags().Bool("development", false, "enable development settings")
-	viperBindFlag("development", rootCmd.PersistentFlags().Lookup("development"))
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -80,10 +80,8 @@ func init() {
 	// NATS related flags
 	serveCmd.Flags().String("nats-url", "nats://127.0.0.1:4222", "NATS server connection url")
 	viperBindFlag("nats.url", serveCmd.Flags().Lookup("nats-url"))
-	serveCmd.Flags().String("nats-token", "", "NATS auth token")
-	viperBindFlag("nats.token", serveCmd.Flags().Lookup("nats-token"))
-	serveCmd.Flags().String("nats-nkey", "", "Path to the file containing the NATS nkey keypair")
-	viperBindFlag("nats.nkey", serveCmd.Flags().Lookup("nats-nkey"))
+	serveCmd.Flags().String("nats-creds-file", "", "Path to the file containing the NATS credentials file")
+	viperBindFlag("nats.creds-file", serveCmd.Flags().Lookup("nats-creds-file"))
 	serveCmd.Flags().String("nats-subject-prefix", "equinixmetal.governor.events", "prefix for NATS subjects")
 	viperBindFlag("nats.subject-prefix", serveCmd.Flags().Lookup("nats-subject-prefix"))
 	serveCmd.Flags().String("nats-queue-group", "equinixmetal.governor.addons.gov-slack-addon", "queue group for load balancing messages across NATS consumers")
@@ -123,10 +121,14 @@ func serve(cmdCtx context.Context, v *viper.Viper) error {
 	}
 	defer auf.Close()
 
-	nc, err := newNATSConnection()
+	nc, natsClose, err := newNATSConnection(
+		viper.GetString("nats.creds-file"),
+		viper.GetString("nats.url"))
 	if err != nil {
 		logger.Fatalw("failed to create NATS client connection", "error", err)
 	}
+
+	defer natsClose()
 
 	natsClient, err := natssrv.NewNATSClient(
 		natssrv.WithNATSLogger(logger.Desugar()),
@@ -197,26 +199,23 @@ func serve(cmdCtx context.Context, v *viper.Viper) error {
 }
 
 // newNATSConnection creates a new NATS connection
-func newNATSConnection() (*nats.Conn, error) {
-	opts := []nats.Option{}
-
-	if viper.GetBool("development") {
-		logger.Debug("enabling development settings")
-
-		opts = append(opts, nats.Token(viper.GetString("nats.token")))
-	} else {
-		opt, err := nats.NkeyOptionFromSeed(viper.GetString("nats-nkey"))
-		if err != nil {
-			return nil, err
-		}
-
-		opts = append(opts, opt)
+func newNATSConnection(credsFile, url string) (*nats.Conn, func(), error) {
+	opts := []nats.Option{
+		nats.Name(appName),
 	}
 
-	return nats.Connect(
-		viper.GetString("nats-url"),
-		opts...,
-	)
+	if credsFile != "" {
+		opts = append(opts, nats.UserCredentials(credsFile))
+	} else {
+		return nil, nil, ErrMissingNATSCreds
+	}
+
+	nc, err := nats.Connect(url, opts...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return nc, nc.Close, nil
 }
 
 // validateMandatoryFlags collects the mandatory flag validation
@@ -225,10 +224,6 @@ func validateMandatoryFlags() error {
 
 	if viper.GetString("nats.url") == "" {
 		errs = append(errs, ErrNATSURLRequired.Error())
-	}
-
-	if viper.GetString("nats.token") == "" && viper.GetString("nats.nkey") == "" {
-		errs = append(errs, ErrNATSAuthRequired.Error())
 	}
 
 	if viper.GetString("slack.token") == "" {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 version: "3.9"
 
+# TODO(sthwang): fix docker-compose
 services:
   app:
     build:


### PR DESCRIPTION
[JIRA](DEL-1774)

Update the Nats Connection function to connect using nats creds instead of a nats token. This will break the docker-compose for now, but instructions have been updated.

# Testing

Tested against local governor-api and published/read message on nats.

